### PR TITLE
chore: update biome schema to 2.3.14

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.14/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
## Summary

- Align `$schema` URL in biome.json with the installed CLI version (2.3.11 → 2.3.14)

## Test plan

- [x] Pre-commit hooks pass (biome, type-check)
- [x] Pre-push hooks pass (build, Playwright e2e)
- [ ] Verify Vercel preview deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)